### PR TITLE
Flags the lib/esm directory as an ESM module.

### DIFF
--- a/lib/esm/package.json
+++ b/lib/esm/package.json
@@ -1,0 +1,1 @@
+{ "type": "module" }


### PR DESCRIPTION
This is necessary for Node to load this package as a module.