### PR TITLE
Add TS types field to exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   "types": "lib/index.d.ts",
   "exports": {
     ".": {
+      "types": "./lib/index.d.ts",
       "import": "./lib/esm/index.js",
       "default": "./lib/index.js"
-    },
-    "./index.d.ts": "./lib/index.d.ts"
+    }
   },
   "scripts": {
     "bench": "node test/benchmark/index.js",


### PR DESCRIPTION
This PR add the "types" field to the export map for [TS usage](https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing). This should also fix the [skypack build](https://cdn.skypack.dev/error/build:@scure/base@v1.1.1-ejMyx1kNgL5TcNqy5uvl) - in the same vein as similar PRs in noble-{ed25519, hashes, secp256k1}

Sorry about the flood of small PRs to the relevant repos, I just looked into all the packages that I do use in my travels.