### PR TITLE
Add deno mod.ts with deno execution test

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,0 +1,1 @@
+export * from './index.ts';

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "bench": "node test/benchmark/index.js",
     "build": "tsc -d && tsc -p tsconfig.esm.json",
     "lint": "prettier --check index.ts",
-    "test": "node test/index.js"
+    "test": "node test/index.js",
+    "test:deno": "deno test test/deno.ts"
   },
   "author": "Paul Miller (https://paulmillr.com)",
   "license": "MIT",

--- a/test/deno.ts
+++ b/test/deno.ts
@@ -1,0 +1,35 @@
+import { assertEquals, assertThrows } from 'https://deno.land/std@0.146.0/testing/asserts.ts';
+import { decode } from 'https://deno.land/std/encoding/hex.ts';
+import BASE58_VECTORS from './vectors/base58.json' assert { type: 'json' };
+import BASE58_XMR_VECTORS from './vectors/base58_xmr.json' assert { type: 'json' };
+import { base58, base58xmr, utils } from '../mod.ts';
+
+const hexToArray = (hex: string) => decode(new TextEncoder().encode(hex));
+
+Deno.test('deno: base58: vectors', () => {
+  for (let i = 0; i < BASE58_VECTORS.length; i++) {
+    const { decodedHex, encoded } = BASE58_VECTORS[i];
+
+    assertEquals(base58.encode(hexToArray(decodedHex)), encoded, `encode ${i}`);
+  }
+});
+
+Deno.test('deno: base58: xmr vectors (valid)', () => {
+  for (let i = 0; i < BASE58_XMR_VECTORS.validAddrs.length; i++) {
+    const decAddr = BASE58_XMR_VECTORS.decodedAddrs[i];
+    const validAddr = BASE58_XMR_VECTORS.validAddrs[i];
+
+    assertEquals(base58xmr.encode(hexToArray(decAddr)), validAddr, `encode ${i}`);
+    assertEquals(base58xmr.decode(validAddr), hexToArray(decAddr), `decode ${i}`);
+  }
+});
+
+Deno.test('deno: utils: padding', () => {
+  const coder = utils.padding(4, '=');
+
+  assertEquals(coder.encode(['1']), ['1', '=']);
+
+  // these check for invalids, so the inputs are meant to be type-unsafe
+  assertThrows(() => coder.encode(['1', 1, true] as unknown as string[]));
+  assertThrows(() => coder.decode(['1', 1, true, '='] as unknown as string[]));
+});


### PR DESCRIPTION
This PR adds -

1. The root `mod.ts` as per https://github.com/paulmillr/scure-base/issues/8
2. A Deno test `test/deno.ts` that consumes `mod.ts` (some basic tests repeated)
3. A new target for `deno:test` in `package.json` to execute 2 above

It does not repeat all the tests that are there, but rather just ensures that the actual imports from `mod.ts` works and it functional.