### PR TITLE
docs(readme): add example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
-# scure-base
+# [@scure/base](https://paulmillr.com/noble/#scure)
+  * [Usage](#usage)
+  * [Design rationale](#design-rationale)
+  * [Security](#security)
+  * [Example Applications usage](#example-applications-usage)
+  * [License](#license)
 
-Secure, [audited](#security) and 0-dep implementation of bech32, base64, base58, base32 & base16.
+<small><i><a href='https://github.com/sponsors/paulmillr/'>You could fund my work with GitHub Sponsorship</a></i></small>
+
+
+## Overview
+
+**Secure**, [audited](#security) and 0-dep implementation of bech32, base64, base58, base32 & base16.
 
 - Supports ESM and common.js
 - Written in [functional style](#design-rationale), uses chaining
@@ -14,7 +24,7 @@ Secure, [audited](#security) and 0-dep implementation of bech32, base64, base58,
 
 > **scure** — secure, independently audited packages for every use case.
 
-- Audited by a third-party
+- Audited by a third-party[^1]
 - Releases are signed with PGP keys and built transparently with NPM provenance
 - Check out all libraries:
   [base](https://github.com/paulmillr/scure-base),
@@ -22,9 +32,13 @@ Secure, [audited](#security) and 0-dep implementation of bech32, base64, base58,
   [bip39](https://github.com/paulmillr/scure-bip39),
   [btc-signer](https://github.com/paulmillr/scure-btc-signer)
 
+[^1]: Audits-Report TypeScript Hashing Libraries (Published 12.2021). Cure53, Dr.-Ing. M. Heiderich, Dr. A. Pirker, Dipl.-Ing. David Gstir [https://cure53.de/pentest-report_hashing-libs.pdf](https://cure53.de/pentest-report_hashing-libs.pdf)
+
+
 ## Usage
 
-> npm install @scure/base
+> npm install @scure/base      
+
 
 ```js
 import { base16, base32, base64, base58 } from '@scure/base';
@@ -114,7 +128,7 @@ base58checksum = {
 But instead of creating two big functions for each specific case,
 we create them from tiny composamble building blocks:
 
-```
+```js
 base58checksum = chain(checksum(), radix(), alphabet())
 ```
 
@@ -166,6 +180,25 @@ The library has been audited by Cure53 on Jan 5, 2022. Check out the audit [PDF]
    was extracted to a separate package called `micro-base`
 3. After the audit we've decided to use NPM namespace for security. Since `@micro` namespace was taken, we've renamed the package to `@scure/base`
 
-## License
+## Example Applications usage
 
-MIT (c) Paul Miller [(https://paulmillr.com)](https://paulmillr.com), see LICENSE file.
+Examples of applications that are using `scure-base` 
+
+### [`truestamp/prefixed-api-key`](https://github.com/truestamp/prefixed-api-key)
+
+[https://github.com/truestamp/prefixed-api-key](https://github.com/truestamp/prefixed-api-key)
+
+A fork of seamapi/prefixed-api-key this is essentially a complete re-write to enhance the cryptographic security properties and safety when verifying a key. The keys and verifiers of these two libraries are not compatible.
+
+> [Motivating post on the issues with using JWT from fly.io](https://fly.io/blog/api-tokens-a-tedious-survey/)
+
+#### Securely encoded/decode the Base58Check values
+
+Base58Check encoding of this random value results in a URL safe string that also encodes four bytes of a SHA-256 hash that serves as a checksum value and prevents typos. The audited paulmillr/scure-base library is used to encoded/decode the Base58Check values.[^2]
+
+[^2]: truestamp/prefixed-api-key: Module for generating a prefixed API Key. (July 2023). [https://github.com/truestamp/prefixed-api-key#secret](https://github.com/truestamp/prefixed-api-key#secret)
+
+
+## License    
+
+MIT (c) Paul Miller [(https://paulmillr.com)](https://paulmillr.com), see [LICENSE](./LICENSE) file.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # [@scure/base](https://paulmillr.com/noble/#scure)
   * [Usage](#usage)
   * [Design rationale](#design-rationale)
@@ -10,7 +11,7 @@
 
 ## Overview
 
-**Secure**, [audited](#security) and 0-dep implementation of bech32, base64, base58, base32 & base16.
+🔐 [Audited](#security) and 0-dep implementation of `bech32`, `base64`, `base58`, `base32` & `base16`.
 
 - Supports ESM and common.js
 - Written in [functional style](#design-rationale), uses chaining
@@ -24,15 +25,15 @@
 
 > **scure** — secure, independently audited packages for every use case.
 
-- Audited by a third-party[^1]
+- Audited by a third-party, Cure53[^1]
 - Releases are signed with PGP keys and built transparently with NPM provenance
 - Check out all libraries:
-  [base](https://github.com/paulmillr/scure-base),
-  [bip32](https://github.com/paulmillr/scure-bip32),
-  [bip39](https://github.com/paulmillr/scure-bip39),
-  [btc-signer](https://github.com/paulmillr/scure-btc-signer)
+  [scure-base](https://github.com/paulmillr/scure-base),
+  [scure-bip32](https://github.com/paulmillr/scure-bip32),
+  [scure-bip39](https://github.com/paulmillr/scure-bip39),
+  [scure-btc-signer](https://github.com/paulmillr/scure-btc-signer)
 
-[^1]: Audits-Report TypeScript Hashing Libraries (Published 12.2021). Cure53, Dr.-Ing. M. Heiderich, Dr. A. Pirker, Dipl.-Ing. David Gstir [https://cure53.de/pentest-report_hashing-libs.pdf](https://cure53.de/pentest-report_hashing-libs.pdf)
+[^1]: Audits-Report TypeScript Hashing Libraries (Published 12.2021). Cure53, Dr.-Ing. M. Heiderich, Dr. A. Pirker, Dipl.-Ing. David Gstir. [SECURITY](./SECURITY.md)
 
 
 ## Usage
@@ -58,7 +59,7 @@ base16.encode(data);
 base32hex.encode(data);
 ```
 
-base58check is a special case: you need to pass `sha256()` function:
+**base58check** is a special case: you need to pass `sha256()` function.
 
 ```js
 import { base58check } from '@scure/base';
@@ -171,9 +172,9 @@ constant sized input, because variable length sized input from user can cause Do
 On the other hand, if both bases are power of same number (like `2**8 <-> 2**64`),
 there is linear algorithm. For now we have implementation for power-of-two bases only (radix2).
 
-## Security
+## [SECURITY.md](./SECURITY.md)
 
-The library has been audited by Cure53 on Jan 5, 2022. Check out the audit [PDF](./audit/2022-01-05-cure53-audit-nbl2.pdf) & [URL](https://cure53.de/pentest-report_hashing-libs.pdf). See [changes since audit](https://github.com/paulmillr/scure-base/compare/1.0.0..main).
+The library has been audited by Cure53 on Jan 5, 2022. [SECURITY.md](./SECURITY.md) Reference audit [PDF](./audit/2022-01-05-cure53-audit-nbl2.pdf) & [URL](https://cure53.de/pentest-report_hashing-libs.pdf). See [changes since audit](https://github.com/paulmillr/scure-base/compare/1.0.0..main). 
 
 1. The library was initially developed for [js-ethereum-cryptography](https://github.com/ethereum/js-ethereum-cryptography)
 2. At commit [ae00e6d7](https://github.com/ethereum/js-ethereum-cryptography/commit/ae00e6d7d24fb3c76a1c7fe10039f6ecd120b77e), it
@@ -199,6 +200,8 @@ Base58Check encoding of this random value results in a URL safe string that also
 [^2]: truestamp/prefixed-api-key: Module for generating a prefixed API Key. (July 2023). [https://github.com/truestamp/prefixed-api-key#secret](https://github.com/truestamp/prefixed-api-key#secret)
 
 
-## License    
+## License  
 
-MIT (c) Paul Miller [(https://paulmillr.com)](https://paulmillr.com), see [LICENSE](./LICENSE) file.
+Licensed under the MIT [LICENSE](./LICENSE)    
+     
+Copyright (C) 2023 Paul Miller [(https://paulmillr.com)](https://paulmillr.com)   

--- a/README.md
+++ b/README.md
@@ -1,31 +1,25 @@
+# scure-base
 
-# [@scure/base](https://paulmillr.com/noble/#scure)
-  * [Usage](#usage)
-  * [Design rationale](#design-rationale)
-  * [Security](#security)
-  * [Example Applications usage](#example-applications-usage)
-  * [License](#license)
+Audited and 0-dep implementation of bech32, base64, base58, base32 & base16.
 
-<small><i><a href='https://github.com/sponsors/paulmillr/'>You could fund my work with GitHub Sponsorship</a></i></small>
-
-
-## Overview
-
-🔐 [Audited](#security) and 0-dep implementation of `bech32`, `base64`, `base58`, `base32` & `base16`.
-
-- Supports ESM and common.js
-- Written in [functional style](#design-rationale), uses chaining
-- Has unique tests which ensure correctness
-- Matches specs
+- [🔒 Audited](#security) by an independent security firm
+- 🔻 Tree-shaking-friendly: use only what's necessary, other code won't be included
+- 🔍 Unique tests which ensure correctness
+- ✍️ Written in [functional style](#design-rationale), easily composable
+- 💼 Matches specs
   - [BIP173](https://en.bitcoin.it/wiki/BIP_0173), [BIP350](https://en.bitcoin.it/wiki/BIP_0350) for bech32 / bech32m
   - [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648) (aka RFC 3548) for Base16, Base32, Base32Hex, Base64, Base64Url
-  - [Base58](https://www.ietf.org/archive/id/draft-msporny-base58-03.txt), [Base58check](https://en.bitcoin.it/wiki/Base58Check_encoding), [Base32 Crockford](https://www.crockford.com/base32.html)
+  - [Base58](https://www.ietf.org/archive/id/draft-msporny-base58-03.txt),
+    [Base58check](https://en.bitcoin.it/wiki/Base58Check_encoding),
+    [Base32 Crockford](https://www.crockford.com/base32.html)
+
+Check out [Projects using scure-base](#projects-using-scure-base).
 
 ### This library belongs to _scure_
 
 > **scure** — secure, independently audited packages for every use case.
 
-- Audited by a third-party, Cure53[^1]
+- Audited by a third-party
 - Releases are signed with PGP keys and built transparently with NPM provenance
 - Check out all libraries:
   [scure-base](https://github.com/paulmillr/scure-base),
@@ -33,18 +27,23 @@
   [scure-bip39](https://github.com/paulmillr/scure-bip39),
   [scure-btc-signer](https://github.com/paulmillr/scure-btc-signer)
 
-[^1]: Audits-Report TypeScript Hashing Libraries (Published 12.2021). Cure53, Dr.-Ing. M. Heiderich, Dr. A. Pirker, Dipl.-Ing. David Gstir. [SECURITY](./SECURITY.md)
-
-
 ## Usage
 
-> npm install @scure/base      
+> npm install @scure/base
 
+We support all major platforms and runtimes. The library is hybrid ESM / Common.js package.
 
 ```js
 import { base16, base32, base64, base58 } from '@scure/base';
 // Flavors
-import { base58xmr, base58xrp, base32hex, base32crockford, base64url, base64urlnopad } from '@scure/base';
+import {
+  base58xmr,
+  base58xrp,
+  base32hex,
+  base32crockford,
+  base64url,
+  base64urlnopad,
+} from '@scure/base';
 
 const data = Uint8Array.from([1, 2, 3]);
 base64.decode(base64.encode(data));
@@ -59,7 +58,7 @@ base16.encode(data);
 base32hex.encode(data);
 ```
 
-**base58check** is a special case: you need to pass `sha256()` function.
+base58check is a special case: you need to pass `sha256()` function:
 
 ```js
 import { base58check } from '@scure/base';
@@ -129,7 +128,7 @@ base58checksum = {
 But instead of creating two big functions for each specific case,
 we create them from tiny composamble building blocks:
 
-```js
+```
 base58checksum = chain(checksum(), radix(), alphabet())
 ```
 
@@ -172,36 +171,25 @@ constant sized input, because variable length sized input from user can cause Do
 On the other hand, if both bases are power of same number (like `2**8 <-> 2**64`),
 there is linear algorithm. For now we have implementation for power-of-two bases only (radix2).
 
-## [SECURITY.md](./SECURITY.md)
+## Security
 
-The library has been audited by Cure53 on Jan 5, 2022. [SECURITY.md](./SECURITY.md) Reference audit [PDF](./audit/2022-01-05-cure53-audit-nbl2.pdf) & [URL](https://cure53.de/pentest-report_hashing-libs.pdf). See [changes since audit](https://github.com/paulmillr/scure-base/compare/1.0.0..main). 
+The library has been audited by Cure53 on Jan 5, 2022. Check out the audit [PDF](./audit/2022-01-05-cure53-audit-nbl2.pdf) & [URL](https://cure53.de/pentest-report_hashing-libs.pdf). See [changes since audit](https://github.com/paulmillr/scure-base/compare/1.0.0..main).
 
-1. The library was initially developed for [js-ethereum-cryptography](https://github.com/ethereum/js-ethereum-cryptography)
-2. At commit [ae00e6d7](https://github.com/ethereum/js-ethereum-cryptography/commit/ae00e6d7d24fb3c76a1c7fe10039f6ecd120b77e), it
-   was extracted to a separate package called `micro-base`
-3. After the audit we've decided to use NPM namespace for security. Since `@micro` namespace was taken, we've renamed the package to `@scure/base`
+The library was initially developed for [js-ethereum-cryptography](https://github.com/ethereum/js-ethereum-cryptography).
+At commit [ae00e6d7](https://github.com/ethereum/js-ethereum-cryptography/commit/ae00e6d7d24fb3c76a1c7fe10039f6ecd120b77e),
+it was extracted to a separate package called `micro-base`.
+After the audit we've decided to use `@scure` NPM namespace for security.
 
-## Example Applications usage
+## Resources
 
-Examples of applications that are using `scure-base` 
+### Projects using scure-base
 
-### [`truestamp/prefixed-api-key`](https://github.com/truestamp/prefixed-api-key)
+- [prefixed-api-key](https://github.com/truestamp/prefixed-api-key):
+  A re-write of seamapi/prefixed-api-key that enhances the
+  cryptographic security properties and safety when verifying a key. The keys and verifiers
+  of these two libraries are not compatible.
+  [Motivating post on the issues with using JWT from fly.io](https://fly.io/blog/api-tokens-a-tedious-survey/)
 
-[https://github.com/truestamp/prefixed-api-key](https://github.com/truestamp/prefixed-api-key)
+## License
 
-A fork of seamapi/prefixed-api-key this is essentially a complete re-write to enhance the cryptographic security properties and safety when verifying a key. The keys and verifiers of these two libraries are not compatible.
-
-> [Motivating post on the issues with using JWT from fly.io](https://fly.io/blog/api-tokens-a-tedious-survey/)
-
-#### Securely encoded/decode the Base58Check values
-
-Base58Check encoding of this random value results in a URL safe string that also encodes four bytes of a SHA-256 hash that serves as a checksum value and prevents typos. The audited paulmillr/scure-base library is used to encoded/decode the Base58Check values.[^2]
-
-[^2]: truestamp/prefixed-api-key: Module for generating a prefixed API Key. (July 2023). [https://github.com/truestamp/prefixed-api-key#secret](https://github.com/truestamp/prefixed-api-key#secret)
-
-
-## License  
-
-Licensed under the MIT [LICENSE](./LICENSE)    
-     
-Copyright (C) 2023 Paul Miller [(https://paulmillr.com)](https://paulmillr.com)   
+MIT (c) Paul Miller [(https://paulmillr.com)](https://paulmillr.com), see LICENSE file.


### PR DESCRIPTION
Added an application that is using it. We are looking at making API key usage for external users and decided on using this package. 

Additionally, added some markdown syntax improvements. 

I also added a link to your github sponsorship page.

Cheers