### PR TITLE
wip: CashAddr basic implementation #13

### DIFF
--- a/test/cashaddr.test.js
+++ b/test/cashaddr.test.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+const { should } = require('micro-should');
+const { cashaddr } = require('..');
+
+const CASHADDR_VALID = [{
+  string: 'prefix:x64nx6hz',
+  prefix: 'prefix',
+  words: [],
+}, {
+  string: 'p:gpf8m4h7',
+  prefix: 'p',
+  words: [],
+}, {
+  string: 'bitcoincash:qpzry9x8gf2tvdw0s3jn54khce6mua7lcw20ayyn',
+  prefix: 'bitcoincash',
+  words:  [
+    0,  1,  2,  3,  4,  5,  6,  7,  8, 9, 10, 11, 12, 13, 14, 15, 16, 17,
+    18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+  ],
+}, {
+  string: 'bchtest:testnetaddress4d6njnut',
+  prefix: 'bchtest',
+  words: [11, 25, 16, 11, 19, 25, 11, 29, 13, 13,  3, 25, 16, 16],
+}, {
+  string: 'bchreg:555555555555555555555555555555555555555555555udxmlmrz',
+  prefix: 'bchreg',
+  words: [
+    20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20,
+    20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20,
+    20],
+}];
+
+for (let v of CASHADDR_VALID) {
+  should(`encode ${v.prefix} ${v.words}`, () => {
+    assert.deepStrictEqual(cashaddr.encode(v.prefix, v.words), v.string.toLowerCase());
+  });
+  should(`encode/decode ${v.prefix} ${v.words}`, () => {
+    const expected = { prefix: v.prefix.toLowerCase(), words: v.words };
+    assert.deepStrictEqual(
+      cashaddr.decode(cashaddr.encode(v.prefix, v.words)),
+      expected
+    );
+  });
+  should(`decode ${v.string}`, () => {
+    const expected = { prefix: v.prefix.toLowerCase(), words: v.words };
+    assert.deepStrictEqual(cashaddr.decodeUnsafe(v.string), expected);
+    assert.deepStrictEqual(cashaddr.decode(v.string), expected);
+  });
+  should(`throw on ${v.string} with 1 bit flipped`, () => {
+    const buffer = Buffer.from(v.string, 'utf8');
+    buffer[v.string.lastIndexOf(':') + 1] ^= 0x1; // flip a bit, after the prefix
+    const str = buffer.toString('utf8');
+    assert.deepStrictEqual(cashaddr.decodeUnsafe(str), undefined);
+    assert.throws(() => cashaddr.decode(str));
+  });
+}
+
+if (require.main === module) should.run();

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ require('./bases.test.js');
 require('./rfc4648.test.js');
 require('./base58.test.js');
 require('./bech32.test.js');
+require('./cashaddr.test.js');
 require('./bip173.test.js');
 
 should.run();


### PR DESCRIPTION
Basic implementation of `CashAddr` encoding.

Specification: https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md

Other implementations:
* https://github.com/bcoin-org/bstring/blob/master/lib/cashaddr-browser.js
* https://github.com/ealmansi/cashaddrjs/blob/master/src/cashaddr.js
* https://github.com/bcoin-org/bcash/blob/master/lib/primitives/address.js

Implementation details:
* `BigInt` is used in checksum calculation to handle bitwise operations on 5 * 8 bit numbers.
* `convertRadix` is used instead of `convertRadix2` to convert number to checksum bits.
* I decided not to merge the implementations of `bech32` and `cashaddr` because it brings many `if`s and complicated logic.
* `bech32` and `cashaddr` shares `Bech32Decoded` and `Bech32DecodedWithArray` interface. Should it be renamed or copied to a new one?
* `cashaddr` doesn't have length limit.
* Do I understand correctly that [`Version byte`](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md#version-byte) logic should be implemented in top level library like `btc-signer`?

TODO:
* more tests
