### PR TITLE
fix: bech32 prefix length

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -482,6 +482,7 @@ function genBech32(encoding: 'bech32' | 'bech32m') {
       throw new Error(`bech32.encode prefix should be string, not ${typeof prefix}`);
     if (!Array.isArray(words) || (words.length && typeof words[0] !== 'number'))
       throw new Error(`bech32.encode words should be array of numbers, not ${typeof words}`);
+    if (prefix.length === 0) throw new TypeError(`Invalid prefix length ${prefix.length}`);
     const actualLength = prefix.length + 7 + words.length;
     if (limit !== false && actualLength > limit)
       throw new TypeError(`Length ${actualLength} exceeds limit ${limit}`);

--- a/test/bech32.test.js
+++ b/test/bech32.test.js
@@ -69,6 +69,15 @@ const BECH32_INVALID_DECODE = [
 
 const BECH32_INVALID_ENCODE = [
   {
+    prefix: '',
+    words: [],
+  },
+  {
+    prefix:
+      'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzfoobar',
+    words: [],
+  },
+  {
     prefix: 'abc',
     words: [128],
   },
@@ -181,6 +190,15 @@ const BECH32M_INVALID_DECODE = [
 ];
 
 const BECH32M_INVALID_ENCODE = [
+  {
+    prefix: '',
+    words: [],
+  },
+  {
+    prefix:
+      'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzfoobar',
+    words: [],
+  },
   {
     prefix: 'abc',
     words: [128],


### PR DESCRIPTION
https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#bech32

> The human-readable part, which is intended to convey the type of data, or anything else that is relevant to the reader. This part MUST contain 1 to 83 US-ASCII characters

Current implementation allows to do:

```js
console.log(bech32.encode('', []))
// 10a06t8
```
But decode fails with error:
```js
console.log(bech32.decode('10a06t8'))
```