### PR TITLE
Add overload to Bech32.decode to handle arbitrary string input

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -671,6 +671,7 @@ export interface Bech32 {
     str: `${Prefix}1${string}`,
     limit?: number | false
   ): Bech32Decoded<Prefix>;
+  decode(str: string, limit?: number | false): Bech32Decoded;
   encodeFromBytes(prefix: string, bytes: Uint8Array): string;
   decodeToBytes(str: string): Bech32DecodedWithArray;
   decodeUnsafe(str: string, limit?: number | false): void | Bech32Decoded<string>;


### PR DESCRIPTION
Before this change, it was not possible to decode an arbitrary string from user input without preprocessing it for the library. The reason is we don't always have the strong type `${Prefix}1${string}` or even `${string}1${string}` available. A cast from `string` to `${string}1${string}` is unsafe without an extra runtime check.

Even the tests file in this project mark the use of `string` inputs as type errors:

<img width="1420" height="392" alt="Bildschirmfoto 2025-10-07 um 15 49 35" src="https://github.com/user-attachments/assets/b5bcfa17-6f91-4e9d-8b70-d1eb4f95eb9c" />

But it turns out `genBech32` has the overload and runtime checks already. It just needs to be exposed to the user.

Closes #43